### PR TITLE
feat: Aggiunge il calcolo di incertezza da fattore di risposta

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,8 +137,34 @@
                  <div id="responseFactor-calculator" class="hidden mt-8">
                       <div class="flex justify-between items-center mb-4"><h2 class="text-2xl font-bold text-gray-700">Incertezza da Fattore di Risposta</h2><div><button id="btn-back-to-calibration-choice-2" class="text-sm text-blue-600 hover:underline">‹ Cambia Metodo</button><button id="btn-reset-response-factor" class="ml-4 text-sm bg-red-100 text-red-800 font-semibold py-1 px-3 rounded-md hover:bg-red-200">Reset</button></div></div>
                       <div class="bg-white p-6 rounded-lg shadow-md border border-gray-200 space-y-6">
-                          <div><h3 class="text-lg font-semibold text-gray-800">1. Incertezza Relativa del Metodo</h3><label for="rf-uncertainty-percent" class="block text-sm font-medium text-gray-700 mt-2">Incertezza Relativa % del Fattore di Risposta (u_rel%)</label><input type="number" id="rf-uncertainty-percent" class="w-full sm:w-1/2 p-2 border border-gray-300 rounded-md" placeholder="Es: 1.5"></div>
-                          <div class="space-y-3 pt-4 border-t"><h3 class="text-lg font-semibold text-gray-800">2. Seleziona Livelli di Concentrazione</h3><p class="text-sm text-gray-600 mb-2">Seleziona i campioni (con Valore Atteso) dall'analisi statistica per cui calcolare l'incertezza.</p><div id="rf-sample-checklist" class="space-y-2 max-h-40 overflow-y-auto border p-2 rounded-md"></div><div class="flex space-x-2"><button id="btn-toggle-rf-all" class="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-1 rounded">Seleziona tutti</button><button id="btn-toggle-rf-none" class="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-1 rounded">Deseleziona tutti</button></div></div>
+                          <div>
+                              <h3 class="text-lg font-semibold text-gray-800">1. Criterio di Accettabilità</h3>
+                              <label for="rf-acceptability-criterion" class="block text-sm font-medium text-gray-700 mt-2">Criterio di accettabilità per il fattore di risposta (%)</label>
+                              <input type="number" id="rf-acceptability-criterion" class="w-full sm:w-1/2 p-2 border border-gray-300 rounded-md" placeholder="Es: 20">
+                          </div>
+                          <div class="space-y-4 pt-4 border-t">
+                              <h3 class="text-lg font-semibold text-gray-800">2. Calcolo Incertezza di taratura</h3>
+                              <p class="text-sm text-gray-600 mb-2">Seleziona i livelli di concentrazione (Valori Attesi) dall'analisi statistica per calcolare l'incertezza di taratura, oppure inserisci manualmente un valore di concentrazione.</p>
+                              <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                  <div class="space-y-3">
+                                      <h4 class="font-semibold text-gray-700">Usa Risultati da Analisi Statistica</h4>
+                                      <div id="rf-sample-checklist" class="space-y-2 max-h-40 overflow-y-auto border p-2 rounded-md">
+                                          <!-- Popolato da JS -->
+                                      </div>
+                                      <div class="flex space-x-2">
+                                          <button id="btn-toggle-rf-all" class="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-1 rounded">Seleziona tutti</button>
+                                          <button id="btn-toggle-rf-none" class="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-1 rounded">Deseleziona tutti</button>
+                                      </div>
+                                  </div>
+                                  <div class="space-y-3">
+                                      <h4 class="font-semibold text-gray-700">Inserimento Manuale (singolo livello)</h4>
+                                      <div>
+                                          <label for="rf-manual-conc" class="block text-sm font-medium text-gray-700">Concentrazione Ipotetica (x)</label>
+                                          <input type="number" id="rf-manual-conc" class="w-full p-2 border border-gray-300 rounded-md" placeholder="Es: 10.5">
+                                      </div>
+                                  </div>
+                              </div>
+                          </div>
                           <button id="btn-calculate-response-factor" class="bg-green-600 text-white font-bold py-2 px-5 rounded-lg shadow-lg hover:bg-green-700 transition">Calcola Incertezza di Taratura</button>
                           <div id="rf-results" class="hidden pt-4 border-t"></div>
                       </div>


### PR DESCRIPTION
Implementa una nuova modalità per il calcolo dell'incertezza di taratura basata su un fattore di risposta medio, come alternativa alla retta dei minimi quadrati.

- Aggiunge una nuova sezione nell'interfaccia utente per questa modalità.
- L'utente può inserire un "criterio di accettabilità (%)" per il fattore di risposta.
- Il software calcola e visualizza l'incertezza tipo relativa (`utaratura%`) dividendo il criterio per sqrt(3).
- Calcola l'incertezza tipo (`ux`) per le concentrazioni dei campioni selezionati o per un valore inserito manualmente, usando la formula `ux = Cx * utaratura% / 100`.
- La logica è interamente implementata in JavaScript (`script.js`) in linea con l'architettura esistente.