### PR TITLE
feat: Use sample standard deviation for statistical analysis

### DIFF
--- a/script.js
+++ b/script.js
@@ -1259,7 +1259,7 @@ async function processSample(sample) {
             if (finalData.length > 0) {
                 const n = finalData.length;
                 const mean = n > 0 ? ss.mean(finalData) : 0;
-                const stdDev = n > 1 ? ss.standardDeviation(finalData) : 0;
+                const stdDev = n > 1 ? ss.sampleStandardDeviation(finalData) : 0;
                 const t_value = getTValue(n);
                 const repeatability_limit_r = n > 1 && t_value ? t_value * stdDev : 0;
                 const nominalValue = (sample.expectedValue !== null && !isNaN(sample.expectedValue) && sample.expectedValue !== '') ? parseFloat(sample.expectedValue) : null;


### PR DESCRIPTION
The previous implementation used the population standard deviation (dividing by n). This has been updated to use the sample standard deviation (dividing by n-1) to better reflect that the data being analyzed is a sample of a larger population.