### PR TITLE
Corregge la formula per il calcolo del limite di ripetibilità (r) in …

### DIFF
--- a/manuale.txt
+++ b/manuale.txt
@@ -37,12 +37,13 @@ Misura la dispersione dei dati rispetto alla media. Viene usata la deviazione st
   - `media`: media del campione.
 
 #### 1.4 Limite di Ripetibilità (r)
-Indica il valore massimo atteso per la differenza tra due risultati di misura ottenuti nelle stesse condizioni (stesso operatore, stessa apparecchiatura, breve intervallo di tempo).
-- **Formula:** `r = t * s`
+Indica il valore massimo atteso per la differenza assoluta tra due risultati di misura ottenuti in condizioni di ripetibilità (stesso operatore, stessa apparecchiatura, stesso laboratorio, breve intervallo di tempo).
+- **Formula:** `r = t * s * sqrt(2)`
 - **Termini:**
   - `r`: limite di ripetibilità.
-  - `s`: deviazione standard campionaria.
-  - `t`: valore critico della t di Student per `n-1` gradi di libertà e un livello di confidenza del 95% (bilaterale). I valori di `t` sono riportati in una tabella apposita.
+  - `s`: deviazione standard campionaria delle misure.
+  - `t`: valore critico della t di Student per `n-1` gradi di libertà e un livello di confidenza del 95% (bilaterale).
+  - `sqrt(2)`: fattore che tiene conto del fatto che il limite si applica alla differenza tra *due* risultati di misura.
 
 #### 1.5 Recupero Percentuale (Recovery %)
 Utilizzato per campioni di controllo a concentrazione nota, misura l'accuratezza del metodo confrontando il valore medio misurato con il valore atteso (nominale).

--- a/script.js
+++ b/script.js
@@ -1261,7 +1261,7 @@ async function processSample(sample) {
                 const mean = n > 0 ? ss.mean(finalData) : 0;
                 const stdDev = n > 1 ? ss.sampleStandardDeviation(finalData) : 0;
                 const t_value = getTValue(n);
-                const repeatability_limit_r = n > 1 && t_value ? t_value * stdDev : 0;
+                const repeatability_limit_r = n > 1 && t_value ? t_value * stdDev * Math.sqrt(2) : 0;
                 const nominalValue = (sample.expectedValue !== null && !isNaN(sample.expectedValue) && sample.expectedValue !== '') ? parseFloat(sample.expectedValue) : null;
 
                 const stats = {


### PR DESCRIPTION
…`script.js` e aggiorna il `manuale.txt` per riflettere la modifica.

La formula precedente era `r = t * s`.
La formula corretta, `r = t * s * sqrt(2)`, è stata implementata come richiesto.

- In `script.js`, il calcolo di `repeatability_limit_r` ora include `* Math.sqrt(2)`.
- In `manuale.txt`, la formula è stata aggiornata e la descrizione dei termini è stata migliorata per includere una nota esplicativa sul fattore `sqrt(2)`.