### PR TITLE
feat: Aggiorna formula incertezza per distribuzione rettangolare

### DIFF
--- a/manuale.txt
+++ b/manuale.txt
@@ -196,10 +196,11 @@ L'applicazione supporta diversi tipi di trattamenti, incluse due modalità di di
 
 1.  **Materiale di Riferimento Certificato:**
     - L'incertezza estesa (`U%`) fornita dal certificato viene convertita in incertezza tipo relativa.
-    - **Formula:** `u_rel = (U% / 100) / k`
+    - **Formula:** `u_rel = (U% / 100) / k / sqrt(2)`
     - **Termini:**
       - `U%`: incertezza percentuale riportata sul certificato.
       - `k`: fattore di copertura (tipicamente `k=2` per un livello di confidenza del 95%). Il codice utilizza `k=2`.
+      - `sqrt(2)`: fattore di divisione aggiuntivo per tenere conto di una distribuzione rettangolare dell'incertezza.
 
 2.  **Vetreria Volumetrica (Matracci):**
     - L'incertezza è basata sulla tolleranza del costruttore, assumendo una distribuzione di probabilità rettangolare.

--- a/script.js
+++ b/script.js
@@ -1792,7 +1792,7 @@ function actionCalculateSpikeUncertainty(sampleId) {
         let sum_u_rel_sq;
 
         if (sampleState.initialUncertainty !== null && sampleState.initialUncertainty > 0) {
-            const u_rel_initial = sampleState.initialUncertainty / 200;
+            const u_rel_initial = sampleState.initialUncertainty / (200 * Math.sqrt(2));
             sum_u_rel_sq = Math.pow(u_rel_initial, 2);
             sampleState.initialUncertaintyRelPerc = u_rel_initial * 100;
         } else {
@@ -2247,7 +2247,7 @@ function main() {
                         if (treatment.source.manualConcentration === null || treatment.source.manualUncertainty === null) throw new Error("Dati manuali incompleti.");
                         currentConcentration = treatment.source.manualConcentration;
                         // U% (k=2) -> u_rel
-                        const u_rel_initial = (treatment.source.manualUncertainty / 100) / 2;
+                        const u_rel_initial = (treatment.source.manualUncertainty / 100) / 2 / Math.sqrt(2);
                         sum_u_rel_sq = Math.pow(u_rel_initial, 2);
                     } else if (treatment.source.type === 'spike') {
                         if (treatment.source.spikeSampleId === null) throw new Error("Matrix spike non selezionato.");


### PR DESCRIPTION
Modifica la formula per il calcolo dell'incertezza tipo relativa del materiale di riferimento certificato per tenere conto di una distribuzione rettangolare.

La formula precedente era:
u_rel = (U% / 100) / k

La nuova formula è:
u_rel = (U% / 100) / k / sqrt(2)

Questa modifica è stata applicata in due punti nel file `script.js`:
1. Nella funzione `actionCalculateSpikeUncertainty` per il calcolo dello spike.
2. Nella funzione `actionCalculateTreatmentChain` per l'inserimento manuale dei dati.

Inoltre, il file `manuale.txt` è stato aggiornato per riflettere la nuova formula e la sua giustificazione.