### PR TITLE
Fix(script): Resolve application freeze by removing duplicate variabl…

### DIFF
--- a/script.js
+++ b/script.js
@@ -1889,7 +1889,6 @@ function actionCalculateSpikeUncertainty(sampleId) {
         const summary = summaryLines.join('<br>');
 
         // NUOVO: Logica per le verifiche di preparazione e accuratezza
-        const sample = appState.samples.find(s => s.id == sampleId);
         const nominalValue = parseFloat(sample.expectedValue);
         const calculatedConcentration = currentConcentration;
         const meanValue = appState.results[sampleId]?.statistics?.mean;


### PR DESCRIPTION
…e declaration

The application was freezing due to a `SyntaxError` in `script.js`. The error, "Identifier 'sample' has already been declared," was caused by a duplicate declaration of the `sample` constant within the `actionCalculateSpikeUncertainty` function.

This commit removes the redundant declaration, allowing the script to execute without errors and resolving the application freeze.