### PR TITLE
Refactor: Remove debug tab and export buttons, update uncertainty text

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,6 @@
                      <button data-tab-name="validazione" id="tab-validazione" class="tab-btn whitespace-nowrap py-4 px-1 border-b-2 font-medium text-lg text-gray-500 hover:text-blue-600 hover:border-blue-300">
                         Verifica Validazione
                     </button>
-                    <button data-tab-name="debug" id="tab-debug" class="tab-btn whitespace-nowrap py-4 px-1 border-b-2 font-medium text-lg text-red-500 hover:text-red-600 hover:border-red-300">
-                        Debug
-                    </button>
                 </nav>
             </div>
 
@@ -108,11 +105,6 @@
                 <section id="results-section" class="mt-10">
                     <div class="flex justify-between items-center border-b-2 border-gray-300 pb-2 mb-6">
                         <h2 class="text-2xl font-bold text-gray-700">Report Finale</h2>
-                        <div id="export-buttons" class="hidden space-x-2">
-                            <button id="btn-export-pdf" title="Esporta in PDF" class="text-gray-500 hover:text-red-600 p-2 rounded-full hover:bg-gray-200 transition"><svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg></button>
-                            <button id="btn-export-excel" title="Esporta in Excel" class="text-gray-500 hover:text-green-600 p-2 rounded-full hover:bg-gray-200 transition"><svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" /></svg></button>
-                            <button id="btn-export-word" title="Esporta in Word" class="text-gray-500 hover:text-blue-600 p-2 rounded-full hover:bg-gray-200 transition"><svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg></button>
-                        </div>
                     </div>
                     <div id="results-container" class="space-y-6"></div>
                 </section>
@@ -237,7 +229,7 @@
             <div id="content-estesa" class="hidden">
                 <div class="bg-white p-6 rounded-lg shadow-md border border-gray-200">
                     <h2 class="text-2xl font-bold text-gray-700 mb-4">Calcolo Incertezza Estesa</h2>
-                    <p class="text-gray-600 mb-6">Questa sezione riepiloga tutti i contributi e calcola l'incertezza estesa (k=2, 95%) per ogni campione analizzato.</p>
+                    <p class="text-gray-600 mb-6">Questa sezione riepiloga tutti i contributi e calcola l'incertezza estesa per ogni campione analizzato.</p>
                     <div id="extended-uncertainty-container">
                         <!-- I risultati verranno renderizzati qui da script.js -->
                         <p class="text-center text-gray-500 italic p-8">Nessun dato da visualizzare. Esegui prima i calcoli nelle altre sezioni.</p>
@@ -347,19 +339,6 @@
                  </div>
             </div>
 
-            <!-- NUOVA SCHEDA: Debug -->
-            <div id="content-debug" class="hidden">
-                 <div class="bg-gray-800 text-white p-4 rounded-lg shadow-md border border-gray-600">
-                    <h2 class="text-2xl font-bold text-gray-300 mb-4">Stato Interno dell'Applicazione (appState)</h2>
-                    <pre id="debug-state-view" class="text-sm whitespace-pre-wrap break-all"></pre>
-                    <div id="test-runner-container" style="display: none;">
-                        <div class="mt-4">
-                            <button id="btn-run-tests" class="bg-yellow-500 text-black font-semibold py-2 px-4 rounded-lg shadow-md hover:bg-yellow-600 transition">Run All Tests</button>
-                        </div>
-                        <div id="test-results-container" class="mt-4 space-y-2"></div>
-                    </div>
-                 </div>
-            </div>
         </main>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -412,7 +412,6 @@ function render() {
     renderExpandedUncertainty(); // <-- AGGIUNTA
     renderLibraryTabs(); // <-- Funzione per le librerie
     renderLibraries(); // <-- Funzione per le tabelle delle librerie
-    renderDebugInfo();
 }
 
 function renderCalibrationSolutionUncertainty() {
@@ -1521,12 +1520,6 @@ function renderProjectInfo() {
     document.getElementById('project-method').value = appState.project.method;
     document.getElementById('project-component').value = appState.project.component;
 }
-function renderDebugInfo() {
-    const debugView = document.getElementById('debug-state-view');
-    if (debugView) {
-        debugView.textContent = JSON.stringify(appState, null, 2);
-    }
-}
 
 function renderExpandedUncertainty() {
     const container = document.getElementById('extended-uncertainty-container');
@@ -1604,7 +1597,6 @@ function renderResultsOnly() {
     resultsContainer.innerHTML = '';
 
     const hasResults = appState.samples.some(s => appState.results[s.id] && (appState.results[s.id].statistics || appState.results[s.id].error));
-    document.getElementById('export-buttons').classList.toggle('hidden', !hasResults);
 
     appState.samples.forEach(sample => {
         const result = appState.results[sample.id];
@@ -3575,24 +3567,11 @@ function main() {
         }
     });
 
-    document.getElementById('project-name').addEventListener('input', e => { appState.project.projectName = e.target.value; renderDebugInfo(); });
+    document.getElementById('project-name').addEventListener('input', e => { appState.project.projectName = e.target.value; });
     document.getElementById('btn-rename-project').addEventListener('click', actionRenameProject);
-    document.getElementById('project-objective').addEventListener('input', e => { appState.project.objective = e.target.value; renderDebugInfo(); });
-    document.getElementById('project-method').addEventListener('input', e => { appState.project.method = e.target.value; renderDebugInfo(); });
-    document.getElementById('project-component').addEventListener('input', e => { appState.project.component = e.target.value; renderDebugInfo(); });
-
-    // --- Automated Tests Event Listener ---
-    const testRunnerButton = document.getElementById('btn-run-tests');
-    if (testRunnerButton) {
-        testRunnerButton.addEventListener('click', () => {
-            // Make the container visible when tests are run
-            const testRunnerContainer = document.getElementById('test-runner-container');
-            if (testRunnerContainer) {
-                testRunnerContainer.style.display = 'block';
-            }
-            runAllTests();
-        });
-    }
+    document.getElementById('project-objective').addEventListener('input', e => { appState.project.objective = e.target.value; });
+    document.getElementById('project-method').addEventListener('input', e => { appState.project.method = e.target.value; });
+    document.getElementById('project-component').addEventListener('input', e => { appState.project.component = e.target.value; });
 
     // --- Event Listeners Scheda Incertezza di Preparazione ---
     const prepContainer = document.getElementById('content-preparazione');


### PR DESCRIPTION
This commit addresses three specific user requests:

1.  **Remove Debug Tab:** The 'Debug' tab, its content, and all associated JavaScript logic (including the `renderDebugInfo` function and test runner) have been completely removed from the application.

2.  **Remove Export Buttons:** The PDF, Excel, and Word export buttons in the 'Analisi Statistica' report section have been removed from the HTML. The corresponding JavaScript code that managed their visibility has also been deleted.

3.  **Update Uncertainty Text:** The descriptive text in the 'Incertezza Estesa' tab has been updated to remove the specific reference to '(k=2, 95%)', making it more general as requested.