### PR TITLE
feat: Add compact view for project reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,17 +358,34 @@
                     </div>
 
                     <!-- Selettori principali e pulsanti di esportazione -->
-                    <div class="flex justify-between items-center mb-8 p-4 bg-gray-100 rounded-lg border">
-                        <div>
-                            <h3 class="font-semibold text-gray-700 mb-2">Organizza report per:</h3>
-                            <div class="flex space-x-6">
-                                <div class="flex items-center">
-                                    <input id="report-group-by-sample" name="report-grouping" type="radio" value="sample" class="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500" checked>
-                                    <label for="report-group-by-sample" class="ml-2 block text-sm font-medium text-gray-700">Campione</label>
+                    <div class="flex justify-between items-start mb-8 p-4 bg-gray-100 rounded-lg border">
+                        <div class="flex items-start space-x-10">
+                            <!-- Organizzazione -->
+                            <div>
+                                <h3 class="font-semibold text-gray-700 mb-2">Organizza report per:</h3>
+                                <div class="flex space-x-6">
+                                    <div class="flex items-center">
+                                        <input id="report-group-by-sample" name="report-grouping" type="radio" value="sample" class="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500" checked>
+                                        <label for="report-group-by-sample" class="ml-2 block text-sm font-medium text-gray-700">Campione</label>
+                                    </div>
+                                    <div class="flex items-center">
+                                        <input id="report-group-by-feature" name="report-grouping" type="radio" value="feature" class="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500">
+                                        <label for="report-group-by-feature" class="ml-2 block text-sm font-medium text-gray-700">Caratteristica</label>
+                                    </div>
                                 </div>
-                                <div class="flex items-center">
-                                    <input id="report-group-by-feature" name="report-grouping" type="radio" value="feature" class="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500">
-                                    <label for="report-group-by-feature" class="ml-2 block text-sm font-medium text-gray-700">Caratteristica</label>
+                            </div>
+                            <!-- Rappresentazione -->
+                            <div>
+                                <h3 class="font-semibold text-gray-700 mb-2">Scegli la rappresentazione:</h3>
+                                <div class="flex space-x-6">
+                                    <div class="flex items-center">
+                                        <input id="report-representation-extended" name="report-representation" type="radio" value="extended" class="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500" checked>
+                                        <label for="report-representation-extended" class="ml-2 block text-sm font-medium text-gray-700">Estesa</label>
+                                    </div>
+                                    <div class="flex items-center">
+                                        <input id="report-representation-compact" name="report-representation" type="radio" value="compact" class="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500">
+                                        <label for="report-representation-compact" class="ml-2 block text-sm font-medium text-gray-700">Compatta</label>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/script.js
+++ b/script.js
@@ -396,6 +396,7 @@ function getInitialAppState() {
         treatments: [],
         reportSettings: {
             grouping: 'sample', // 'sample' or 'feature'
+            representation: 'extended', // 'extended' or 'compact'
             selections: {
                 statistica: {
                     dati_grezzi: false,
@@ -3717,7 +3718,7 @@ function gatherReportData() {
         groups: []
     };
 
-    // Helper functions to generate data blocks for each section
+    // Helper functions to generate data blocks for each section (for extended view)
     const getStatisticaBlocks = (sampleId, selections) => {
         const blocks = [];
         const result = appState.results[sampleId];
@@ -3929,49 +3930,108 @@ function gatherReportData() {
         return blocks;
     };
 
-    const featureMap = {
-        'Analisi Statistica': (sampleId) => getStatisticaBlocks(sampleId, settings.selections.statistica),
-        'Incertezza di Preparazione': (sampleId) => getPreparazioneBlocks(sampleId, settings.selections.preparazione),
-        'Incertezza di Taratura da Retta': (sampleId) => getTaraturaRettaBlocks(sampleId, settings.selections['taratura-retta']),
-        'Incertezza di Taratura da FR': (sampleId) => getTaraturaFrBlocks(sampleId, settings.selections['taratura-fr']),
-        'Incertezza Estesa': (sampleId) => getEstesaBlocks(sampleId, settings.selections.estesa)
-    };
-    const featureNames = Object.keys(featureMap);
+    if (settings.representation === 'compact') {
+        const componentName = appState.project.component || 'N/D';
 
-    if (settings.grouping === 'sample') {
-        appState.samples.forEach(sample => {
-            const items = [];
-            featureNames.forEach(featureName => {
-                const blocks = featureMap[featureName](sample.id);
-                if (blocks.length > 0) {
-                    items.push({ itemTitle: featureName, blocks: blocks });
-                }
-            });
+        const paramDefinitions = [
+            { check: () => settings.selections.statistica.statistiche_descrittive, displayName: 'Media', getValue: (id) => appState.results[id]?.statistics?.mean },
+            { check: () => settings.selections.statistica.statistiche_descrittive, displayName: 'Dev. Std.', getValue: (id) => appState.results[id]?.statistics?.stdDev },
+            { check: () => settings.selections.statistica.statistiche_descrittive, displayName: 'CV %', getValue: (id) => appState.results[id]?.statistics?.cv_percent },
+            { check: () => settings.selections.preparazione.trattamenti, displayName: 'Conc. Finale Tratt.', getValue: (id) => appState.treatments.find(t=>t.sampleId === id)?.results?.finalConcentration },
+            { check: () => settings.selections.preparazione.trattamenti, displayName: 'u_c % Tratt.', getValue: (id) => appState.treatments.find(t=>t.sampleId === id)?.results?.u_comp_rel_perc },
+            { check: () => settings.selections['taratura-retta'].incertezza_livello, displayName: 'u_rel % Retta', getValue: (id) => appState.calibration.results?.samples.find(s=>s.sampleName === appState.samples.find(x=>x.id===id)?.name)?.ux_rel_perc },
+            { check: () => settings.selections['taratura-fr'].incertezza_livello, displayName: 'u_x FR', getValue: (id) => appState.rfCalibration.results?.samples.find(s=>s.sampleName === appState.samples.find(x=>x.id===id)?.name)?.ux },
+            { check: () => settings.selections.estesa.risultati, displayName: 'U% Estesa', getValue: (id) => calculateExpandedUncertainty(id)?.U_rel_perc },
+        ];
 
-            if (items.length > 0) {
-                reportData.groups.push({
-                    groupTitle: sample.name,
-                    items: items
+        const activeParams = paramDefinitions.filter(p => p.check());
+
+        if (activeParams.length === 0) {
+            alert("Per il report compatto, selezionare almeno un parametro numerico dalle sezioni (es. 'Statistiche descrittive', 'Risultati finali', etc.).");
+            return null;
+        }
+
+        const formatValue = (value) => {
+            if (value === null || typeof value === 'undefined') return '-';
+            if (typeof value === 'number') return value.toPrecision(3);
+            return value;
+        };
+
+        if (settings.grouping === 'sample') {
+            const headers = ['Componente', 'Campione', ...activeParams.map(p => p.displayName)];
+            const rows = appState.samples.map(sample => {
+                const row = [componentName, sample.name];
+                activeParams.forEach(paramDef => {
+                    const value = paramDef.getValue(sample.id);
+                    row.push(formatValue(value));
                 });
-            }
-        });
-    } else { // grouping by feature
-        featureNames.forEach(featureName => {
-            const items = [];
+                return row;
+            });
+            reportData.groups.push({
+                groupTitle: 'Report Compatto per Campione',
+                items: [{ itemTitle: 'Tabella Riassuntiva', blocks: [{ type: 'table', content: { headers, rows } }] }]
+            });
+        } else { // grouping by feature
+            const headers = ['Componente', 'Caratteristica', ...appState.samples.map(s => s.name)];
+            const rows = activeParams.map(paramDef => {
+                const row = [componentName, paramDef.displayName];
+                appState.samples.forEach(sample => {
+                    const value = paramDef.getValue(sample.id);
+                    row.push(formatValue(value));
+                });
+                return row;
+            });
+            reportData.groups.push({
+                groupTitle: 'Report Compatto per Caratteristica',
+                items: [{ itemTitle: 'Tabella Riassuntiva', blocks: [{ type: 'table', content: { headers, rows } }] }]
+            });
+        }
+
+    } else { // 'extended' representation (original logic)
+        const featureMap = {
+            'Analisi Statistica': (sampleId) => getStatisticaBlocks(sampleId, settings.selections.statistica),
+            'Incertezza di Preparazione': (sampleId) => getPreparazioneBlocks(sampleId, settings.selections.preparazione),
+            'Incertezza di Taratura da Retta': (sampleId) => getTaraturaRettaBlocks(sampleId, settings.selections['taratura-retta']),
+            'Incertezza di Taratura da FR': (sampleId) => getTaraturaFrBlocks(sampleId, settings.selections['taratura-fr']),
+            'Incertezza Estesa': (sampleId) => getEstesaBlocks(sampleId, settings.selections.estesa)
+        };
+        const featureNames = Object.keys(featureMap);
+
+        if (settings.grouping === 'sample') {
             appState.samples.forEach(sample => {
-                const blocks = featureMap[featureName](sample.id);
-                if (blocks.length > 0) {
-                    items.push({ itemTitle: sample.name, blocks: blocks });
+                const items = [];
+                featureNames.forEach(featureName => {
+                    const blocks = featureMap[featureName](sample.id);
+                    if (blocks.length > 0) {
+                        items.push({ itemTitle: featureName, blocks: blocks });
+                    }
+                });
+
+                if (items.length > 0) {
+                    reportData.groups.push({
+                        groupTitle: sample.name,
+                        items: items
+                    });
                 }
             });
-
-            if (items.length > 0) {
-                 reportData.groups.push({
-                    groupTitle: featureName,
-                    items: items
+        } else { // grouping by feature
+            featureNames.forEach(featureName => {
+                const items = [];
+                appState.samples.forEach(sample => {
+                    const blocks = featureMap[featureName](sample.id);
+                    if (blocks.length > 0) {
+                        items.push({ itemTitle: sample.name, blocks: blocks });
+                    }
                 });
-            }
-        });
+
+                if (items.length > 0) {
+                     reportData.groups.push({
+                        groupTitle: featureName,
+                        items: items
+                    });
+                }
+            });
+        }
     }
 
     return reportData;
@@ -4005,6 +4065,11 @@ function setupReportEventListeners() {
 
         if (target.name === 'report-grouping') {
             appState.reportSettings.grouping = target.value;
+            return;
+        }
+
+        if (target.name === 'report-representation') {
+            appState.reportSettings.representation = target.value;
             return;
         }
 


### PR DESCRIPTION
This feature introduces a new "compact" representation for the "Report Progetto" tab, complementing the existing "extended" view.

The user can now choose between two layouts for the report:
- Estesa (Extended): The original layout with detailed sections.
- Compatta (Compact): A new layout that presents all selected data in a single summary table.

The compact view has two modes based on the "Organizza report per" selection:
- Grouped by Sample: Creates a single table with one row per sample and columns for each selected parameter.
- Grouped by Characteristic: Creates a single table with one row per parameter and columns for each sample.

This has been implemented by:
- Adding UI radio buttons in `index.html` to select the representation.
- Updating `script.js` to manage the new state.
- Overhauling the `gatherReportData` function to handle both compact and extended logic safely, ensuring the original functionality is preserved.