### PR TITLE
feat: Aggiunge incertezza da controllo di taratura

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,16 @@
                  <div id="calibration-choice">
                      <h2 class="text-2xl font-bold text-gray-700 mb-4">Calcolo Incertezza di Taratura</h2>
                      <p class="text-gray-600 mb-6">Scegli il modello di calibrazione da utilizzare per la stima dell'incertezza.</p>
+
+                     <!-- Nuovo campo per MAX_RSD_ICV% -->
+                     <div class="bg-white p-6 rounded-lg shadow-md border border-gray-200 mb-6">
+                         <h3 class="text-lg font-semibold text-gray-800">Criterio di Accettabilità sul Controllo di Taratura (Opzionale)</h3>
+                         <p class="text-sm text-gray-500 mt-1 mb-4">Se fornito, questo valore verrà usato per calcolare un contributo di incertezza aggiuntivo basato sul controllo di taratura (ICV).</p>
+                         <div>
+                             <label for="max-rsd-icv" class="block text-sm font-medium text-gray-700">MAX_RSD_ICV% (0-100)</label>
+                             <input type="number" id="max-rsd-icv" min="0" max="100" step="any" class="mt-1 w-full sm:w-1/2 p-2 border border-gray-300 rounded-md" placeholder="Es: 15">
+                         </div>
+                     </div>
                      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                          <div id="btn-select-regression" class="bg-white p-6 rounded-lg shadow-md border border-gray-200 hover:border-blue-500 hover:shadow-lg transition cursor-pointer">
                              <h3 class="text-xl font-semibold text-gray-800">Retta dei Minimi Quadrati</h3>

--- a/manuale_tecnico.txt
+++ b/manuale_tecnico.txt
@@ -176,6 +176,29 @@ Questo metodo alternativo non richiede la costruzione di una retta, ma si basa s
       - `x_k`: concentrazione del campione.
       - `u_taratura%`: incertezza tipo relativa di taratura calcolata sopra.
 
+#### PARTE C: CONTRIBUTO OPZIONALE DA CONTROLLO DI TARATURA (ICV)
+
+L'applicazione permette di introdurre un contributo di incertezza aggiuntivo, basato su un criterio di accettabilità definito dall'utente per il controllo di taratura (noto anche come ICV - Initial Calibration Verification). Questo calcolo è opzionale.
+
+1.  **Input Utente:**
+    - `MAX_RSD_ICV%`: L'utente può inserire un valore percentuale che rappresenta la massima deviazione standard relativa accettabile per le misure di un controllo di taratura.
+
+2.  **Calcolo dell'Incertezza Relativa da ICV (u_icv%)**
+    - Se il valore `MAX_RSD_ICV%` è fornito, viene utilizzato per calcolare un'incertezza tipo relativa, assumendo una distribuzione rettangolare.
+    - **Formula:** `u_icv% = MAX_RSD_ICV% / sqrt(3)`
+    - **Termini:**
+      - `MAX_RSD_ICV%`: il criterio di accettabilità inserito dall'utente.
+      - `sqrt(3)`: fattore di divisione per una distribuzione rettangolare.
+
+3.  **Logica di Selezione del Contributo di Incertezza**
+    - Per ogni campione, l'applicazione calcola sia l'incertezza di taratura standard (`ux`, come descritto nelle Parti A o B) sia il contributo dall'ICV.
+    - **Contributo ICV Assoluto:** `u_icv_abs = (u_icv% / 100) * |x_k|`
+    - **Condizione:** L'applicazione confronta i due valori: `u_icv_abs` vs `ux`.
+    - **Decisione:**
+      - Se `u_icv_abs > ux`, il contributo del controllo di taratura è considerato predominante e viene utilizzato come incertezza di taratura finale per quel campione.
+      - Altrimenti, viene mantenuta l'incertezza di taratura standard `ux`.
+    - La scelta effettuata e il valore non utilizzato vengono riportati sia nelle tabelle a schermo sia nella reportistica estesa per garantire la massima tracciabilità.
+
 ---------------------------------------------------
 
 ### SEZIONE 4: INCERTEZZA DI PREPARAZIONE (INCERTEZZA COMPOSITA)

--- a/manuale_utente.txt
+++ b/manuale_utente.txt
@@ -2,6 +2,32 @@
 # MANUALE UTENTE - GUIDA RAPIDA #
 #################################
 
+### SEZIONE: INCERTEZZA DI TARATURA
+
+#### Nuovo Calcolo Opzionale: Incertezza da Controllo di Taratura (ICV)
+
+È stata introdotta una nuova funzionalità che permette di considerare l'incertezza derivante dal criterio di accettabilità dei controlli di taratura (ICV). Questo è utile quando la variabilità del sistema, misurata tramite i controlli, è maggiore dell'incertezza calcolata dal modello di taratura.
+
+**Come utilizzare la nuova funzionalità:**
+
+1.  **Naviga alla scheda "Incertezza di Taratura".**
+2.  Troverai un nuovo riquadro: **"Criterio di Accettabilità sul Controllo di Taratura (Opzionale)"**.
+3.  **Inserisci il valore (opzionale):** Nel campo `MAX_RSD_ICV%`, inserisci il criterio massimo di deviazione standard relativa che il tuo laboratorio accetta per un controllo di taratura (es. 15 per 15%).
+    *   Se questo campo viene lasciato vuoto, l'applicazione funzionerà come sempre, utilizzando solo l'incertezza del modello di taratura (retta o fattore di risposta).
+    *   Se viene inserito un valore, l'applicazione eseguirà un calcolo aggiuntivo.
+
+**Come interpretare i nuovi risultati:**
+
+Quando un valore per `MAX_RSD_ICV%` è fornito, la tabella dei risultati "Incertezza per Livello di Concentrazione" mostrerà delle nuove colonne per una maggiore chiarezza:
+*   **u_taratura:** L'incertezza calcolata dal modello di taratura (retta o fattore di risposta).
+*   **u_ICV:** L'incertezza calcolata a partire dal tuo criterio `MAX_RSD_ICV%`.
+*   **u_finale:** Il valore di incertezza che verrà effettivamente utilizzato nei calcoli successivi. L'applicazione sceglie automaticamente il valore più alto tra `u_taratura` e `u_ICV`.
+*   **Fonte:** Indica quale dei due contributi è stato scelto.
+
+Se una riga è evidenziata in blu, significa che il contributo `u_ICV` è risultato maggiore ed è stato scelto come incertezza finale per quel campione. Questa informazione verrà riportata anche nei report estesi (PDF, Word, Excel) per garantire la completa tracciabilità dell'analisi.
+
+---
+
 Questo manuale fornisce istruzioni pratiche sull'utilizzo delle funzionalità dell'applicazione.
 
 ---

--- a/script.js
+++ b/script.js
@@ -429,6 +429,7 @@ function getInitialAppState() {
             pipettes: deepCopy(DEFAULT_PIPETTE_LIBRARY),
         },
         calibration: {
+            max_rsd_icv: null, // NUOVO CAMPO OPZIONALE
             points: [
                 { id: 'cal-point-1', x: 0.0, y: 0.05, unit: 'µg/L' },
                 { id: 'cal-point-2', x: 0.1, y: 0.18, unit: 'µg/L' },
@@ -1341,14 +1342,22 @@ function renderCalibrationTab() {
             const line = results.line;
             const samples = results.samples;
 
-            const samplesHTML = samples.map(s => `
-                <tr class="border-b hover:bg-gray-50">
+            const samplesHTML = samples.map(s => {
+                const u_icv_display = s.ux_icv !== null ? s.ux_icv.toPrecision(6) : 'N/A';
+                const highlightClass = s.source === 'Controllo Taratura' ? 'bg-blue-50' : '';
+
+                return `
+                <tr class="border-b hover:bg-gray-50 ${highlightClass}">
                     <td class="p-2 font-medium">${s.sampleName}</td>
                     <td class="p-2 font-mono">${s.nominalConc.toPrecision(6)}</td>
-                    <td class="p-2 font-mono">${s.ux.toPrecision(6)}</td>
-                    <td class="p-2 font-mono">${s.ux_rel_perc.toFixed(2)} %</td>
+                    <td class="p-2 font-mono">${s.ux_calib_orig.toPrecision(6)}</td>
+                    <td class="p-2 font-mono">${u_icv_display}</td>
+                    <td class="p-2 font-mono font-bold">${s.ux.toPrecision(6)}</td>
+                    <td class="p-2 font-mono font-bold">${s.ux_rel_perc.toFixed(2)} %</td>
+                    <td class="p-2">${s.source}</td>
                 </tr>
-            `).join('');
+                `
+            }).join('');
 
             const resultsHTML = `
                 <h3 class="text-lg font-semibold text-gray-800 my-4 pt-4 border-t">Risultati del Calcolo</h3>
@@ -1368,10 +1377,13 @@ function renderCalibrationTab() {
                     <table class="w-full text-sm text-left">
                         <thead class="bg-gray-100">
                             <tr>
-                                <th class="p-2 font-medium text-gray-600 rounded-tl-lg">Nome Campione/Livello</th>
-                                <th class="p-2 font-medium text-gray-600">Concentrazione Nominale (x)</th>
-                                <th class="p-2 font-medium text-gray-600">Incertezza Tipo (u_x)</th>
-                                <th class="p-2 font-medium text-gray-600 rounded-tr-lg">Incertezza Relativa (%)</th>
+                                <th class="p-2 font-medium text-gray-600">Campione</th>
+                                <th class="p-2 font-medium text-gray-600">Conc. (x)</th>
+                                <th class="p-2 font-medium text-gray-600">u_taratura</th>
+                                <th class="p-2 font-medium text-gray-600">u_ICV</th>
+                                <th class="p-2 font-medium text-gray-600">u_finale</th>
+                                <th class="p-2 font-medium text-gray-600">u_finale (%)</th>
+                                <th class="p-2 font-medium text-gray-600">Fonte</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -1397,13 +1409,22 @@ function renderRfResults() {
         if (results.error) {
             resultsContainer.innerHTML = `<div class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mt-4" role="alert"><p class="font-bold">Errore di Calcolo</p><p>${results.error}</p></div>`;
         } else if (results.samples) {
-            const samplesHTML = results.samples.map(s => `
-                <tr class="border-b hover:bg-gray-50">
+            const samplesHTML = results.samples.map(s => {
+                const u_icv_display = s.ux_icv !== null ? s.ux_icv.toPrecision(6) : 'N/A';
+                const highlightClass = s.source === 'Controllo Taratura' ? 'bg-blue-50' : '';
+
+                return `
+                <tr class="border-b hover:bg-gray-50 ${highlightClass}">
                     <td class="p-2 font-medium">${s.sampleName}</td>
                     <td class="p-2 font-mono">${s.nominalConc.toPrecision(6)}</td>
-                    <td class="p-2 font-mono">${s.ux.toPrecision(6)}</td>
+                    <td class="p-2 font-mono">${s.ux_calib_orig.toPrecision(6)}</td>
+                    <td class="p-2 font-mono">${u_icv_display}</td>
+                    <td class="p-2 font-mono font-bold">${s.ux.toPrecision(6)}</td>
+                    <td class="p-2 font-mono font-bold">${s.ux_rel_perc.toFixed(2)} %</td>
+                    <td class="p-2">${s.source}</td>
                 </tr>
-            `).join('');
+                `
+            }).join('');
 
             const resultsHTML = `
                 <h3 class="text-lg font-semibold text-gray-800 my-4 pt-4 border-t">Risultati del Calcolo</h3>
@@ -1419,9 +1440,13 @@ function renderRfResults() {
                     <table class="w-full text-sm text-left">
                         <thead class="bg-gray-100">
                             <tr>
-                                <th class="p-2 font-medium text-gray-600 rounded-tl-lg">Nome Campione/Livello</th>
-                                <th class="p-2 font-medium text-gray-600">Concentrazione Nominale (x)</th>
-                                <th class="p-2 font-medium text-gray-600 rounded-tr-lg">Incertezza Tipo (u_x)</th>
+                                <th class="p-2 font-medium text-gray-600">Campione</th>
+                                <th class="p-2 font-medium text-gray-600">Conc. (x)</th>
+                                <th class="p-2 font-medium text-gray-600">u_taratura</th>
+                                <th class="p-2 font-medium text-gray-600">u_ICV</th>
+                                <th class="p-2 font-medium text-gray-600">u_finale</th>
+                                <th class="p-2 font-medium text-gray-600">u_finale (%)</th>
+                                <th class="p-2 font-medium text-gray-600">Fonte</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -2934,10 +2959,32 @@ function actionCalculateRegression() {
         const sampleResults = tasks.map(task => {
             const y_predicted = (lineParams.b * task.xk) + lineParams.a;
             const uncertaintyResult = calculateUncertaintyForSample(lineParams, y_predicted, task.p);
+
+            // Inizializza l'oggetto finale con i risultati originali
+            let finalUncertainty = {
+                ...uncertaintyResult,
+                ux_calib_orig: uncertaintyResult.ux, // Salva l'originale
+                ux_icv: null,
+                source: 'Incertezza Taratura'
+            };
+
+            const max_rsd_icv = appState.calibration.max_rsd_icv;
+            if (max_rsd_icv !== null && max_rsd_icv > 0) {
+                const u_c_taratura_perc = max_rsd_icv / Math.sqrt(3);
+                const u_icv = (u_c_taratura_perc / 100) * Math.abs(task.xk);
+                finalUncertainty.ux_icv = u_icv;
+
+                if (u_icv > uncertaintyResult.ux) {
+                    finalUncertainty.ux = u_icv; // Sovrascrive ux con il valore maggiore
+                    finalUncertainty.ux_rel_perc = (task.xk !== 0) ? (u_icv / Math.abs(task.xk)) * 100 : 0;
+                    finalUncertainty.source = 'Controllo Taratura';
+                }
+            }
+
             return {
                 sampleName: task.name,
                 nominalConc: task.xk,
-                ...uncertaintyResult
+                ...finalUncertainty
             };
         });
 
@@ -2991,11 +3038,33 @@ function actionCalculateResponseFactor() {
         }
 
         const sampleResults = tasks.map(task => {
-            const ux = (Math.abs(task.xk) * utaratura_perc) / 100;
+            const ux_calib_orig = (Math.abs(task.xk) * utaratura_perc) / 100;
+
+            let finalUncertainty = {
+                ux: ux_calib_orig,
+                ux_calib_orig: ux_calib_orig,
+                ux_rel_perc: utaratura_perc,
+                ux_icv: null,
+                source: 'Incertezza Taratura'
+            };
+
+            const max_rsd_icv = appState.calibration.max_rsd_icv;
+            if (max_rsd_icv !== null && max_rsd_icv > 0) {
+                const u_c_taratura_perc_icv = max_rsd_icv / Math.sqrt(3);
+                const u_icv = (u_c_taratura_perc_icv / 100) * Math.abs(task.xk);
+                finalUncertainty.ux_icv = u_icv;
+
+                if (u_icv > ux_calib_orig) {
+                    finalUncertainty.ux = u_icv;
+                    finalUncertainty.ux_rel_perc = (task.xk !== 0) ? (u_icv / Math.abs(task.xk)) * 100 : 0;
+                    finalUncertainty.source = 'Controllo Taratura';
+                }
+            }
+
             return {
                 sampleName: task.name,
                 nominalConc: task.xk,
-                ux: ux
+                ...finalUncertainty
             };
         });
 
@@ -4621,11 +4690,14 @@ function gatherReportData() {
                     title: 'Incertezza per Livello di Concentrazione (Retta)',
                     type: 'table',
                     content: {
-                        headers: ['Conc. Nominale', 'Incertezza Tipo (u_x)', 'Incertezza Relativa (%)'],
+                        headers: ['Conc. Nominale', 'u_taratura', 'u_ICV', 'u_finale', 'u_finale (%)', 'Fonte'],
                         rows: [[
                             sampleResult.nominalConc.toPrecision(6),
+                            sampleResult.ux_calib_orig.toPrecision(6),
+                            sampleResult.ux_icv !== null ? sampleResult.ux_icv.toPrecision(6) : 'N/A',
                             sampleResult.ux.toPrecision(6),
-                            `${sampleResult.ux_rel_perc.toFixed(2)} %`
+                            `${sampleResult.ux_rel_perc.toFixed(2)} %`,
+                            sampleResult.source
                         ]]
                     }
                 });
@@ -4661,10 +4733,14 @@ function gatherReportData() {
                     title: 'Incertezza per Livello di Concentrazione (FR)',
                     type: 'table',
                     content: {
-                        headers: ['Conc. Nominale', 'Incertezza Tipo (u_x)'],
+                        headers: ['Conc. Nominale', 'u_taratura', 'u_ICV', 'u_finale', 'u_finale (%)', 'Fonte'],
                         rows: [[
                             sampleResult.nominalConc.toPrecision(6),
-                            sampleResult.ux.toPrecision(6)
+                            sampleResult.ux_calib_orig.toPrecision(6),
+                            sampleResult.ux_icv !== null ? sampleResult.ux_icv.toPrecision(6) : 'N/A',
+                            sampleResult.ux.toPrecision(6),
+                            `${sampleResult.ux_rel_perc.toFixed(2)} %`,
+                            sampleResult.source
                         ]]
                     }
                 });
@@ -5227,6 +5303,25 @@ function main() {
     document.getElementById('btn-add-regression-row').addEventListener('click', actionAddRegressionRow);
     document.getElementById('btn-calculate-regression').addEventListener('click', actionCalculateRegression);
     document.getElementById('btn-calculate-response-factor').addEventListener('click', actionCalculateResponseFactor);
+
+    document.getElementById('max-rsd-icv').addEventListener('input', e => {
+        const input = e.target;
+        let value = input.value;
+
+        // Validation
+        if (value !== '' && (parseFloat(value) < 0 || parseFloat(value) > 100)) {
+            input.classList.add('border-red-500', 'focus:ring-red-500', 'focus:border-red-500');
+            input.classList.remove('focus:ring-indigo-500', 'focus:border-indigo-500');
+            return; // Stop processing if invalid
+        } else {
+            input.classList.remove('border-red-500', 'focus:ring-red-500', 'focus:border-red-500');
+            input.classList.add('focus:ring-indigo-500', 'focus:border-indigo-500');
+        }
+
+        const numValue = value === '' ? null : parseFloat(value);
+        appState.calibration.max_rsd_icv = numValue;
+        setDirty();
+    });
 
     const regressionContainer = document.getElementById('regression-table-container');
     // Use 'change' to handle select dropdowns and when number inputs lose focus.


### PR DESCRIPTION
Implementa una nuova funzionalità per includere un contributo opzionale all'incertezza basato sul criterio di accettabilità del controllo di taratura (ICV).

- Aggiunto un campo di input `MAX_RSD_ICV%` nella scheda Incertezza di Taratura.
- Se il valore è fornito, viene calcolata una `u_icv` basata su una distribuzione rettangolare (`MAX_RSD_ICV% / sqrt(3)`).
- Per ogni campione, questa `u_icv` viene confrontata con l'incertezza di taratura standard (`ux`) e il valore maggiore viene utilizzato per i calcoli successivi.
- Le tabelle dei risultati e i report estesi sono stati aggiornati per mostrare entrambi i contributi di incertezza, il valore finale scelto e la fonte, garantendo la tracciabilità.
- I file di documentazione (`manuale_tecnico.txt` e `manuale_utente.txt`) sono stati aggiornati per descrivere la nuova funzionalità, e `manuale.txt` è stato rinominato come richiesto.