### PR TITLE
Fix: Update Huber test threshold to 4.5

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,7 +133,7 @@ function hubersTest(data) {
     const deviations = data.map(d => Math.abs(d - med));
     const mad = median(deviations);
     if (mad < 1e-9) return [];
-    const threshold = 3.5;
+    const threshold = 4.5;
     const outliers = [];
     data.forEach((value, index) => {
         if ((Math.abs(value - med) / mad) > threshold) {


### PR DESCRIPTION
The threshold for the Huber (MAD) outlier test in the statistical analysis function (`hubersTest`) has been updated from 3.5 to 4.5.

This change aligns the application's statistical analysis with the specified reference standard provided by the user. The validation test case `unichim_179_1_huber_test` remains unchanged as it correctly uses a threshold of 4.5 for its specific verification purpose.