### PR TITLE
feat: Includi il CV% nel calcolo dell'incertezza dei matrix spike

### DIFF
--- a/MANUALE_TECNICO.md
+++ b/MANUALE_TECNICO.md
@@ -248,6 +248,10 @@ L'incertezza composita viene calcolata combinando le singole incertezze tipo rel
   - `u_c_rel`: incertezza tipo composita relativa.
   - `u_rel_i`: incertezza tipo relativa del componente i-esimo (es. materiale di riferimento, matraccio, pipetta).
 
+**Nota per il calcolo dei Matrix Spike:** Nel caso specifico del calcolo dell'incertezza per la preparazione di un *matrix spike*, la formula sopra include un contributo aggiuntivo derivante dalla ripetibilità della misura. Questo contributo è il Coefficiente di Variazione (CV%) ottenuto dall'analisi statistica del campione specifico.
+- **Contributo della Ripetibilità:** `u_rel_ripetibilità = CV% / 100`
+- Il termine `(CV% / 100)²` viene quindi aggiunto alla somma dei quadrati all'interno della radice quadrata.
+
 L'incertezza tipo assoluta finale (`u_c`) si ottiene moltiplicando la relativa per la concentrazione finale: `u_c = u_c_rel * C_finale`.
 
 #### 4.2 Calcolo della Concentrazione nei Passaggi

--- a/script.js
+++ b/script.js
@@ -2427,6 +2427,7 @@ function renderSpikeUncertainty() {
                         <p class="text-sm text-gray-600">Concentrazione Finale Calcolata: <span class="font-bold text-lg text-black">${results.finalConcentration.toPrecision(4)} ${sampleUnit}</span></p>
                         <p class="text-sm text-gray-600">Valore Nominale Campione Preparato: <span class="font-bold text-lg text-black">${parseFloat(sample.expectedValue).toPrecision(4)} ${sampleUnit}</span></p>
                         <p class="text-sm text-gray-600">Valore Medio Campione (da Statistica): <span class="font-bold text-lg text-black">${appState.results[sample.id].statistics.mean.toPrecision(4)} ${sampleUnit}</span></p>
+                        <p class="text-sm text-gray-600">Coefficiente di Variazione, CV (da statistica): <span class="font-bold text-lg text-black">${appState.results[sample.id].statistics.cv_percent.toFixed(2)} %</span></p>
                         <p class="text-sm text-gray-600">Incertezza tipo composta (u_c): <span class="font-bold text-black">${results.u_comp.toPrecision(3)}</span></p>
                         <p class="text-sm text-gray-600">Incertezza tipo composta relativa (u_c %): <span class="font-bold text-black">${results.u_comp_rel_perc.toFixed(2)} %</span></p>
                     </div>
@@ -4741,6 +4742,13 @@ function actionCalculateSpikeUncertainty(sampleId) {
             }
         } else {
             sum_u_rel_sq = 0;
+        }
+
+        // Aggiungi il contributo della ripetibilità (CV%)
+        const stats = appState.results[sampleId]?.statistics;
+        if (stats && stats.cv_percent > 0) {
+            const u_rel_cv = stats.cv_percent / 100;
+            sum_u_rel_sq += Math.pow(u_rel_cv, 2);
         }
 
         for (const step of sampleState.steps) {


### PR DESCRIPTION
Aggiunge il contributo della ripetibilità (CV%) alla formula dell'incertezza composta (`u_c_rel`) per i matrix spike nella funzione `actionCalculateSpikeUncertainty`.

Il valore del CV% viene prelevato dalle statistiche descrittive del campione specifico.

Aggiorna l'interfaccia utente (`renderSpikeUncertainty`) per visualizzare il "Coefficiente di Variazione, CV (da statistica)" nel riepilogo dei risultati.

Aggiorna il file `MANUALE_TECNICO.md` per documentare la nuova formula di calcolo.