### PR TITLE
Fix backward compatibility for old project files

### DIFF
--- a/script.js
+++ b/script.js
@@ -4173,14 +4173,38 @@ async function handleFileLoad(event) {
     reader.onload = async (e) => { // La funzione ora è async
         try {
             const loadedState = JSON.parse(e.target.result);
-            if (!loadedState.version || !loadedState.project) throw new Error("File non valido o corrotto.");
+            if (!loadedState.project) throw new Error("File non valido o corrotto.");
 
-            // Conserva le librerie correnti dell'utente per evitare che vengano sovrascritte
+            // Conserva le librerie e la versione correnti dell'utente
             const currentUserLibraries = deepCopy(appState.libraries);
+            const currentVersion = appState.version;
 
             appState = loadedState;
             appState.libraries = currentUserLibraries; // Ripristina le librerie dell'utente
+            appState.version = currentVersion; // Ripristina la versione dell'applicazione
+
+            // Retrocompatibilità per progetti che non hanno lo stato UI
+            if (!appState.ui) {
+                appState.ui = getInitialAppState().ui;
+            }
             appState.ui.currentFileName = file.name;
+
+            // Retrocompatibilità per la struttura 'treatments' mancante
+            if (!appState.treatments) {
+                console.log("Vecchio formato di progetto rilevato. Creazione della struttura 'treatments' in corso...");
+                appState.treatments = [];
+                // Per ogni campione, crea una voce 'treatmentSample' vuota.
+                // Questo permette a `calculateExpandedUncertainty` di procedere
+                // e includere i contributi di spike e taratura.
+                appState.samples.forEach(sample => {
+                    appState.treatments.push({
+                        id: `ts-${Date.now()}-${sample.id}`,
+                        sampleId: sample.id,
+                        treatments: [],
+                        results: null
+                    });
+                });
+            }
 
             // Compatibility checks
             if (!appState.reportSettings) appState.reportSettings = getInitialAppState().reportSettings;


### PR DESCRIPTION
This commit resolves two issues that occurred when loading project files created with older versions of the application:

1.  **Incorrect Version Display:** The application version in the footer was being overwritten by the version from the loaded project file. The `handleFileLoad` function has been updated to preserve and restore the main application's version during the file loading process.

2.  **Incomplete Uncertainty Calculation:** Older project files lack the `treatments` data structure, causing the expanded uncertainty calculation to fail silently, omitting key contributions. Backward compatibility logic has been added to detect these old formats and create the necessary `treatments` array for each sample, ensuring calculations can proceed correctly.

Additionally, a bug was fixed where loading a file without a `ui` object would cause a crash. The `handleFileLoad` function now initializes a default `ui` object if one is not present in the loaded file.