### PR TITLE
Remove Stale `FIX` Comment

### DIFF
--- a/script.js
+++ b/script.js
@@ -6340,7 +6340,7 @@ function gatherMultiProjectReportData({ grouping }) {
 
             projectState.samples.forEach(sample => {
                 const result = projectState.results[sample.id];
-                const estesaResult = result ? calculateExpandedUncertainty(sample.id, projectState) : null; // FIX: Pass the correct projectState
+                const estesaResult = result ? calculateExpandedUncertainty(sample.id, projectState) : null;
 
                 const content = [
                     { key: 'Nome campione', value: sample.name },


### PR DESCRIPTION
This submission removes a stale `FIX` comment from `script.js`. The comment was identified as outdated because the `projectState` variable it questioned is being passed correctly within the `gatherMultiProjectReportData` function. The removal of this comment improves code clarity.

---
*PR created automatically by Jules for task [8155163021739121904](https://jules.google.com/task/8155163021739121904) started by @moneflo78-crypto*